### PR TITLE
Fix authenticate error when no internet connection

### DIFF
--- a/src/GoSMS/GoSMS.php
+++ b/src/GoSMS/GoSMS.php
@@ -115,13 +115,15 @@ class GoSMS
                 'grant_type' => $this->grantType,
             )
         );
-        
+
         $response = json_decode($result->response);
 
         if ( $result->info->http_code === 400 ) {
             throw new GoSMSException\InvalidCredentials('Bad credentials or grant_type missing');
         } elseif ( $result->info->http_code !== 200 ) {
-            throw new GoSMSException\Another($response->error_description);
+            throw new GoSMSException\Another(
+                isset($response->error_description) ? $response->error_description : $result->error
+            );
         }
 
         $this->token = $response->access_token;


### PR DESCRIPTION
Missing internet connection causes client error with HTTP code 0 and NULL response.
In such case, use error from the client.